### PR TITLE
Update the Set Arch custom fact, to return arm64 for aarch64.

### DIFF
--- a/tasks/main.yaml
+++ b/tasks/main.yaml
@@ -37,7 +37,7 @@
 - block:
     - name: Set Arch 
       set_fact:
-        arch: "{% if '{{ ansible_architecture }}==x86_64' %}amd64{% else %} '{{ ansible_architecture }}' {% endif %}"
+        arch: "{% if ansible_architecture == 'x86_64' %}amd64{% elif ansible_architecture == 'aarch64' %}arm64{% else %}{{ ansible_architecture }}{% endif %}"
 
     ## v1.2.1 changed naming scheme
     - name: Set Download URL for v < 1.2.1


### PR DESCRIPTION
Minor tweak to the arch custom fact that when aarch64 is returned it will use arm64. This affects Raspberry Pi's that I know of as well as Oracle Cloud Arm Compute Instances.